### PR TITLE
Update sponsor.html

### DIFF
--- a/sponsors.html
+++ b/sponsors.html
@@ -14,7 +14,7 @@ image: team-support-background
   <div id="about" class="page-card who-are-we mdl-shadow-card mdl-shadow--2dp mdl-cell mdl-cell--6-col">
     <div class="mdl-card__supporting-text">
       <h3 class="centered-heading">Sponsors</h3>
-      <p>Iron Claw would like to thank all of its sponsors for their support. Without our sponsors, we would be unable to obtain parts our robot, buy our tools, or sign up for competition. Running a robotics team costs a lot of money!</p>
+      <p>Iron Claw would like to thank all of its sponsors for their support. Without our sponsors, we would be unable to obtain parts for our robot, buy our tools, or sign up for competition. Running a robotics team costs a lot of money!</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Just fixed typo in sponsors page description, but there is still two Ace logos, so you might want to eliminate line 53 or 54, unless maybe there were two separate sponsorships, one from the local Ace, and one from the Ace corporation as a whole, like Home Depot.
